### PR TITLE
feat: add Temple of Space and Frost Moon to Region.ini

### DIFF
--- a/releases/Region.ini
+++ b/releases/Region.ini
@@ -1,10 +1,11 @@
 namespace = global\region
-; Region.ini Version 0.4.1
+; Region.ini Version 0.5
 ; Check latest version at: http://github.com/LeoTorreZ/LeoTools/blob/main/releases/Region.ini
 ; Author: golanah921
 ; Minor fixes: LeoTorreZ
 ; Natlan added by WarkolakA
 ; Natlan Resort and Nod-Krai added by Bestie Andrew
+; Temple of Space and Frost Moon added by Lemmmy
 ;
 ; Description: - Detects the current region you walked into or teleported to
 ;
@@ -27,6 +28,8 @@ namespace = global\region
 ; 12: natlan
 ; 13: natlan resort
 ; 14: nod-krai
+; 15: temple of space
+; 16: nod-krai frost moon
 ;------------------------
 ;Update Log
 ;Ver 0.2.1: Fix Natlan tp hash
@@ -34,6 +37,8 @@ namespace = global\region
 ;Ver 0.4: - Added Natlan resort with tp hash and asha ib. Added condition to Natlan team setup screen.
 ;	        - Added Nod-Krai region with tp hash, specialty ib, and team setup screen.
 ;Ver 0.4.1: Fix Nod-Krai party hash
+;Ver 0.5: - Added Temple of Space with tp hash and statue ib
+;         - Added Frost Moon (Nod-Krai) with tp hash, specialty ib, and planet ib
 ;------------------------
 
 [Constants]
@@ -52,6 +57,8 @@ global $chenyu = 0
 global $natlan = 0
 global $natlan_resort = 0
 global $nodkrai = 0
+global $temple_of_space = 0
+global $frost_moon = 0
 global persist $regioncheck = 0
 
 [Present]
@@ -85,6 +92,10 @@ elif $natlan_resort == 1
 	$regioncheck = 13
 elif $nodkrai == 1
 	$regioncheck = 14
+elif $temple_of_space == 1
+	$regioncheck = 15
+elif $frost_moon == 1
+	$regioncheck = 16
 endif
 
 ;Detect mondstadt
@@ -511,9 +522,11 @@ $sumeru_desert = 1
 
 [TextureOverrideAjilenakhNutIB]
 hash = dfd09643
-run = CommandListResetValues
 match_priority = 0
-$sumeru_desert = 1
+if $temple_of_space != 1
+	run = CommandListResetValues
+	$sumeru_desert = 1
+endif
 
 ;Detect fontaine
 
@@ -773,6 +786,59 @@ run = CommandListResetValues
 match_priority = 0
 $nodkrai = 1
 
+;Detect Temple of Space
+
+[TextureOverrideLSTempleOfSpaceTPScreen]
+hash = cb3097a8
+run = CommandListResetValues
+match_priority = 0
+$temple_of_space = 1
+
+[TextureOverrideTempleOfSpaceStatue1IB]
+hash = 15d6315b
+run = CommandListResetValues
+match_priority = 0
+$temple_of_space = 1
+
+[TextureOverrideTempleOfSpaceStatue2IB]
+hash = 774c08b0
+run = CommandListResetValues
+match_priority = 0
+$temple_of_space = 1
+
+[TextureOverrideTempleOfSpaceStatue3IB]
+hash = 122d2f42
+run = CommandListResetValues
+match_priority = 0
+$temple_of_space = 1
+
+[TextureOverrideTempleOfSpaceStatue4IB]
+hash = 9d6c8605
+run = CommandListResetValues
+match_priority = 0
+$temple_of_space = 1
+
+;Detect Frost Moon (Nod-Krai)
+
+[TextureOverrideLSFrostMoonTPScreen]
+hash = 35708c77
+run = CommandListResetValues
+match_priority = 0
+$frost_moon = 1
+
+[TextureOverrideTeardropOfTheMoonIB]
+hash = d5156c71
+run = CommandListResetValues
+match_priority = 0
+$frost_moon = 1
+
+[TextureOverrideFrostMoonTeyvat]
+; teyvat planet visible in the sky while on the frost moon
+hash = 57a4ab35
+run = CommandListResetValues
+match_priority = 0
+$frost_moon = 1
+
 ;Reset all region value
 
 [CommandListResetValues]
@@ -791,3 +857,5 @@ $chenyu = 0
 $natlan = 0
 $natlan_resort = 0
 $nodkrai = 0
+$temple_of_space = 0
+$frost_moon = 0


### PR DESCRIPTION
Adds region detection for Temple of Space (code 15) and Nod-Krai's Frost Moon (code 16).

## Temple of Space (15)

The Temple of Space detection targets the TP screen and four statue models that appear throughout the map.
<img width="400" alt="GenshinImpact_duqngOzzdd" src="https://github.com/user-attachments/assets/e9c080b9-0c95-4c4b-87e8-128efebcaed3" />
<img width="400" alt="GenshinImpact_VjnQHDhTTD" src="https://github.com/user-attachments/assets/1265ff30-65ae-482f-abcb-b64b4422c9ff" />

I experimented with a few different hashes, but unfortunately a lot of them also appear in the Mondstadt expansion, so to err on the side of caution, I've not included any of them. They could possibly be added by gating them in a similar way to the Chenyu Vale hashes, though.
- `4e9635cd`: [Harpastum](<https://genshin-impact.fandom.com/wiki/Harpastum>) enter icon when hovering
- `5aa987d7`: [Etherwing Moth](<https://genshin-impact.fandom.com/wiki/Etherwing_Moth>), local specialty
- Dex's hand icon is unfortunately [part of the UI icon atlas](<https://github.com/user-attachments/assets/ab2f8ad6-f74b-4934-b170-2e7fbaa4f4e4>)

There's also one place in the Temple of Space where a Sumeru material IB ([Ajilenakh Nut](<https://genshin-impact.fandom.com/wiki/Ajilenakh_Nut>)) collides with the TOS IBs. I gated the Ajilenakh Nut IB with an if statement similar to the Chenyu Vale hashes.
<img width="400" alt="GenshinImpact_TfaZztCzGI" src="https://github.com/user-attachments/assets/550c9481-9571-42ef-9ba9-3244fbaff111" />

## Frost Moon (16)

The Frost Moon was much more straightforward. I target the TP screen, the [Teardrop of the Moon](<https://genshin-impact.fandom.com/wiki/Teardrop_of_the_Moon>) local specialty, and the IB for the Teyvat planet that's visible throughout most of the map. I don't know if this same IB appears in the Nod-Krai Archon Quest [Act VIII: True Moon](<https://genshin-impact.fandom.com/wiki/True_Moon>), but most places outdoors in the map render this hash. Some more hashes like the jellyfish in the Moontide Sea could possibly be added if necessary.